### PR TITLE
Add version info from git tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ public class BuildVersion {
     private static final String git_short_sha = "";
     private static final String git_sha = "";
     private static final String git_date = "";
+    private static final String git_tag_version = "";
+
 
     /** returns the version of the project from the gradle build.gradle file. */
     public static String getVersion() {
@@ -57,6 +59,12 @@ public class BuildVersion {
     public static String getGitDate() {
         return git_date;
     }
+    
+    /** returns a human-readable name using closet parent git tag */
+    public static String getGitTagVersion() {
+        return git_tag_version;
+    }
+    
     public static String getDetailedVersion() {
         String out = getGroup()+":"+getName()+":"+getVersion()+" "+getDate();
         if (git_revision.length() > 0) {
@@ -76,7 +84,8 @@ public class BuildVersion {
         out += "    \"revision\": \""+getGitRevision()+"\","+N;
         out += "    \"shortsha\": \""+getGitShortSha()+"\","+N;
         out += "    \"sha\": \""+getGitSha()+"\","+N;
-        out += "    \"date\": \""+getGitDate()+"\""+N;
+        out += "    \"date\": \""+getGitDate()+"\","+N;
+        out += "    \"tagVersion\": \""+getGitTagVersion()+"\""+N;
         out += "  }"+N;
         out += "}";
         return out;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ public class BuildVersion {
     private static final String git_short_sha = "";
     private static final String git_sha = "";
     private static final String git_date = "";
-    private static final String git_tag_version = "";
+    private static final String git_last_tag = "";
+    private static final String git_last_tag_date = "2023-11-20T17:13:22Z";
+    private static final int git_commits_since_last_tag = 0;
 
 
     /** returns the version of the project from the gradle build.gradle file. */
@@ -60,9 +62,19 @@ public class BuildVersion {
         return git_date;
     }
     
-    /** returns a human-readable name using closet parent git tag */
-    public static String getGitTagVersion() {
-        return git_tag_version;
+    /** returns the closet parent git tag */
+    public static String getGitLastTag() {
+        return git_last_tag;
+    }
+    
+    /** returns date of commit of last git tag */
+    public static String getGitLastTagDate() {
+        return git_last_tag_date;
+    }
+    
+    /** returns number of commits since last git tag */
+    public static int getGitCommitsSinceLastTag() {
+        return git_commits_since_last_tag;
     }
     
     public static String getDetailedVersion() {
@@ -85,7 +97,9 @@ public class BuildVersion {
         out += "    \"shortsha\": \""+getGitShortSha()+"\","+N;
         out += "    \"sha\": \""+getGitSha()+"\","+N;
         out += "    \"date\": \""+getGitDate()+"\","+N;
-        out += "    \"tagVersion\": \""+getGitTagVersion()+"\""+N;
+        out += "    \"lastTag\": \""+getGitLastTag()+"\","+N;
+        out += "    \"lastTagDate\": \""+getGitLastTagDate()+"\","+N;
+        out += "    \"commitsSinceLastTag\": "+getGitCommitsSinceLastTag()+N;
         out += "  }"+N;
         out += "}";
         return out;

--- a/src/main/groovy/edu/sc/seis/versionClass/VersionClassPlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/versionClass/VersionClassPlugin.groovy
@@ -165,7 +165,7 @@ public class BuildVersion {
         out += "    \\"revision\\": \\""+getGitRevision()+"\\","+N;
         out += "    \\"shortsha\\": \\""+getGitShortSha()+"\\","+N;
         out += "    \\"sha\\": \\""+getGitSha()+"\\","+N;
-        out += "    \\"date\\": \\""+getGitDate()+"\\""+N;
+        out += "    \\"date\\": \\""+getGitDate()+"\\","+N;
         out += "    \\"tagVersion\\": \\""+getGitTagVersion()+"\\""+N;
         out += "  }"+N;
         out += "}";

--- a/src/main/groovy/edu/sc/seis/versionClass/VersionClassPlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/versionClass/VersionClassPlugin.groovy
@@ -65,6 +65,7 @@ class VersionClassPlugin implements Plugin<Project>  {
             def git_sha = ""
             def git_short_sha = ""
             def git_date = ""
+            def git_tag_version = ""
             //def outFilename = "java/"+project.group.replace('.','/')+"/"+project.name.replace('-','/')+"/BuildVersion.java"
             def outFilename = getBuildVersionFilename(project)
             def outFile = new File(generatedSrcDir, outFilename)
@@ -80,6 +81,8 @@ class VersionClassPlugin implements Plugin<Project>  {
                 git_short_sha = runGitCommand(project.projectDir, cmd)
                 cmd = 'git show -s --format=%cI HEAD'
                 git_date = runGitCommand(project.projectDir, cmd)
+                cmd = 'git describe --tags --always --dirty'
+                git_tag_version = runGitCommand(project.projectDir, cmd)
             }
 
             def f = new FileWriter(outFile)
@@ -103,6 +106,7 @@ public class BuildVersion {
     private static final String git_short_sha = \""""+git_short_sha+"""\";
     private static final String git_sha = \""""+git_sha+"""\";
     private static final String git_date = \""""+git_date+"""\";
+    private static final String git_tag_version = \""""+git_tag_version+"""\";
 
     /** returns the version of the project from the gradle build.gradle file. */
     public static String getVersion() {
@@ -136,6 +140,12 @@ public class BuildVersion {
     public static String getGitDate() {
         return git_date;
     }
+    
+    /** returns a human-readable name using closet parent git tag */
+    public static String getGitTagVersion() {
+        return git_tag_version;
+    }
+    
     public static String getDetailedVersion() {
         String out = getGroup()+":"+getName()+":"+getVersion()+" "+getDate();
         if (git_revision.length() > 0) {
@@ -156,6 +166,7 @@ public class BuildVersion {
         out += "    \\"shortsha\\": \\""+getGitShortSha()+"\\","+N;
         out += "    \\"sha\\": \\""+getGitSha()+"\\","+N;
         out += "    \\"date\\": \\""+getGitDate()+"\\""+N;
+        out += "    \\"tagVersion\\": \\""+getGitTagVersion()+"\\""+N;
         out += "  }"+N;
         out += "}";
         return out;


### PR DESCRIPTION
This plugin does exactly what we need for our work flow but we relay on git tags for versioning internal code.
Added latest tag to git info.

